### PR TITLE
EdOps - Learn 273: adiciona pytest-json como dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pytest-cov==2.10.0
 six==1.15.0
 wcwidth==0.2.5
 zipp==3.1.0
+pytest-json==0.4.0


### PR DESCRIPTION
Atlassian board issue:
[EdOps - LEARN-273](https://trybe.atlassian.net/browse/LEARN-273?atlOrigin=eyJpIjoiZmNmYzQxNmE2ZDkzNDM4ZWI1ZWNmZGZlOTMzY2NmY2QiLCJwIjoiaiJ9)

PR do avaliador:
https://github.com/betrybe/pytest-evaluator-action/pull/1

PR de teste usando a nova action:
https://github.com/tryber/sd-01-tech-news/pull/9

Check que gerou o resultado do avaliador do Pytest com sucesso:
https://github.com/tryber/sd-01-tech-news/pull/9/checks?check_run_id=1125284881